### PR TITLE
Fix the problem of incorrect time unit

### DIFF
--- a/Sources/AppModule/QTAppDelegate.m
+++ b/Sources/AppModule/QTAppDelegate.m
@@ -239,7 +239,7 @@
                 [message appendString:@"Bus: "];
                 [message appendString:NSStringFromClass(module.class)];
                 [message appendFormat:@" execute %@ ",NSStringFromSelector(sel)];
-                [message appendFormat:@"cost %fms", endTime - beginTime];
+                [message appendFormat:@"cost %fms", (endTime - beginTime) * 1e3];
                 NSLog(@"%@",message);
             }
 #pragma clang diagnostic pop


### PR DESCRIPTION
The `CACurrentMediaTime()` function returns a value in seconds.